### PR TITLE
Update to support oxmysql instad of mysql-async

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,6 +5,6 @@ server_only 'yes'
 
 server_scripts {
      'config.lua',
-     '@mysql-async/lib/MySQL.lua',
+     '@oxmysql/lib/MySQL.lua',
      'server.lua'
 }


### PR DESCRIPTION
[oxmysql](https://github.com/overextended/oxmysql) is a modern replacement for MySQL-Async and ghmattimysql 